### PR TITLE
Chore: (Docs) Updates link for support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This [storybook](https://storybooks.js.org) ([source](https://github.com/storybookjs/storybook)) addon allows you to add events for your stories.
 
-[Framework Support](https://github.com/storybookjs/storybook/blob/master/ADDONS_SUPPORT.md)
+[Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
 [Storybook Addon Events Live Demo](https://z4o4z.github.io/storybook-addon-events/index.html)
 


### PR DESCRIPTION
With this small pull request, the Framework support link is updated to its proper location as the Addon Support table is no longer a source of truth.

Addresses #17150